### PR TITLE
Update fs-extra to version 10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "arg": "^5.0.0",
     "bcrypt": "^5.0.1",
     "cuid": "^2.1.8",
-    "fs-extra": "^9.1.0",
+    "fs-extra": "^10.0.0",
     "get-port": "^5.1.1",
     "inquirer": "^8.0.0",
     "tumau": "1.0.0-alpha.85",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3504,7 +3504,16 @@ fs-extra@8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.0, fs-extra@^9.1.0:
+fs-extra@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
+  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
+fs-extra@^9.0.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==


### PR DESCRIPTION
This pull request was created using the JSFIX tool (https://jsfix.live) by Coana.tech (https://coana.tech).
It bumps fs-extra to version 10.0.0.

<strong>Sign up your project [here](https://jsfix.live/scanner) to receive notifications about other packages updates JSFIX can help with.</strong>

***

<h3> Pull request details</h3>

<details open><summary><strong> 🚧 - Manual review items (please check before merge)</strong></summary><blockquote class="pr-blockquote"><details>
<summary>Breaking changes not automatically fixable by JSFIX.</summary><blockquote class="pr-blockquote">

<details open>
<summary>General breaking changes (not related to specific API usages in your code).</summary>

* Require Node.js v12+
</details>

</blockquote></details>

</blockquote></details><details><summary>Additional details</summary><blockquote class="pr-blockquote"><details>
<summary>Breaking changes where JSFIX found that there were no occurrences.</summary>

* Allow copying broken symlinks
* Ensure correct type when destination exists for ensureLink*()/ensureSymlink*()
* Error when attempting to copy*() unknown file type
* Remove undocumented options for remove*()
</details>

</blockquote></details>

***

If you would like to provide feedback to the JSFIX developers, then please leave a comment on this pull request.